### PR TITLE
chore: add commit message instructions for contributors

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,18 @@
+# GitHub Copilot Commit Message Instructions
+
+Follow the Conventional Commits specification.
+The commit message should be structured as follows:
+
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+
+## Rules
+
+- The commit message must start with a type (e.g., feat, fix, docs, style, refactor, perf, test, build, ci)
+- The type should be followed by an optional scope in parentheses, then a colon and a space.
+- The first line (subject) should be a short, descriptive summary of 50 characters or less.
+- The body should provide more detailed context, if necessary.
+- Use the imperative mood (e.g., "Add feature" not "Added feature").


### PR DESCRIPTION
This pull request introduces documentation to standardize commit messages in the repository. It adds a new file with instructions for writing commit messages according to the Conventional Commits specification.

Commit message guidelines:

* Added `.github/git-commit-instructions.md` with detailed instructions for structuring commit messages using the Conventional Commits specification, including type, scope, description, and formatting rules.