### PR TITLE
feat(country-subdivision): implement fetching from OpenHolidays API

### DIFF
--- a/agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/raw-idea.md
+++ b/agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/raw-idea.md
@@ -1,0 +1,3 @@
+# Raw Idea
+
+Now that we have implemented the base data model for CountrySubdivision, when we run the InstallCommand and after we create the countries, we need to fetch the country subdivisions from the OpenHolidays API.

--- a/agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/requirements.md
+++ b/agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/requirements.md
@@ -1,0 +1,118 @@
+# Spec Requirements: Fetch Country Subdivisions
+
+## Initial Description
+Now that we have implemented the base data model for CountrySubdivision, when we run the InstallCommand and after we create the countries, we need to fetch the country subdivisions from the OpenHolidays API.
+
+## Requirements Discussion
+
+### First Round Questions
+
+**Q1: Integration Point** - Should this subdivision fetching run as part of the existing InstallCommand (synchronous during installation), or as a separate command/job (for running independently)?
+**Answer:** As a second `spin()` block for now (synchronous during installation)
+
+**Q2: Countries to Fetch** - Should we fetch subdivisions for all countries, or start with a specific subset (e.g., specific regions or high-priority countries)?
+**Answer:** Start by only fetching Portugal and Spain
+
+**Q3: Subdivision Type Mapping** - The OpenHolidays API returns subdivision types. Should we create a mapping configuration to standardize types across different countries, or use the types as-is from the API?
+**Answer:** Create a mapping configuration. Strategy while testing: go through all countries and save each country subdivision response in the Saloon Fixtures folder to identify all the types.
+
+**Q4: Nested Subdivisions Handling** - How deep should the nesting go? Should we fetch all levels of subdivisions (country → state → region → city, etc.), or limit to a specific depth?
+**Answer:** Look at the `CreateRootCountrySubdivision` action. We will need to create a map/adapter from API responses to data objects.
+
+**Q5: Error Handling** - If fetching subdivisions for a particular country fails (API error, rate limit, etc.), should we skip that country and continue, or halt the entire installation?
+**Answer:** Skip that country and continue with others, and log the error
+
+**Q6: Code Field** - For the `code` field in CountrySubdivision, should we use the short subdivision code (e.g., "PT-11" → "11") or the full ISO code?
+**Answer:** Use the full ISO code
+
+**Q7: Official Languages** - If a subdivision's official languages differ from the parent country, should we inherit from the parent or fetch/parse from the API response?
+**Answer:** When empty, parse as comma-separated list and default to the parent country's languages
+
+**Q8: Rate Limiting** - Should we implement rate limiting or delays between API requests to avoid hitting OpenHolidays API limits?
+**Answer:** Implement a rate limit
+
+**Q9: Existing vs. New Subdivisions** - If we run the install command multiple times, should we skip existing subdivisions or update them (upsert)?
+**Answer:** Upsert them
+
+**Q10: Are there any subdivisions or edge cases we should explicitly exclude?** - Any specific exclusions to be aware of?
+**Answer:** None specified
+
+### Existing Code to Reference
+
+**Similar Features Identified:**
+- Feature: Country creation and processing - The user indicated to look at how countries are being processed
+- Action: `app/Actions/CountrySubdivision/CreateRootCountrySubdivision.php` - This action handles creating root subdivisions with nested children recursively. It accepts `CreateCountrySubdivisionData` objects and creates the hierarchy in a database transaction.
+- Note: User mentioned "We still don't have a service to handle this" - meaning no existing service layer for API fetching/processing exists yet
+
+**Key patterns from CreateRootCountrySubdivision:**
+- Uses dependency injection for `CreateCountrySubdivision` action
+- Wraps operations in `DB::transaction()` for data integrity
+- Recursively processes nested children via `createChildren()` method
+- Separates children data before creating parent, then creates children with parent_id reference
+- Accepts `CreateCountrySubdivisionData` objects with optional children collection
+
+## Visual Assets
+
+### Files Provided:
+No visual assets provided.
+
+### Visual Insights:
+N/A
+
+## Requirements Summary
+
+### Functional Requirements
+- Fetch country subdivisions from OpenHolidays API during InstallCommand execution
+- Add a second `spin()` block (synchronous) after country creation
+- Initially fetch subdivisions for Portugal and Spain only
+- Support nested subdivision hierarchies (unlimited depth based on API response)
+- Map API subdivision types to standardized types using a configuration
+- Use full ISO codes for the `code` field (e.g., "PT-11" not "11")
+- Parse official languages as comma-separated list, defaulting to parent country languages when empty
+- Upsert subdivisions on repeated installations (update existing, create new)
+- Skip countries that fail with errors and continue processing others
+- Log errors for failed countries
+- Implement rate limiting between API requests
+- Save API responses to Saloon Fixtures folder during testing to identify subdivision types
+
+### Reusability Opportunities
+- Reference existing country creation/processing patterns
+- Use `CreateRootCountrySubdivision` action as template for understanding data structure and nesting
+- Leverage existing `CreateCountrySubdivisionData` data object
+- Follow existing Action pattern (not Service layer, as none exists yet)
+- Use existing Saloon HTTP client setup for OpenHolidays API integration
+
+### Scope Boundaries
+
+**In Scope:**
+- Fetching subdivisions from OpenHolidays API
+- Creating mapping/adapter from API responses to `CreateCountrySubdivisionData` objects
+- Implementing subdivision type mapping configuration
+- Handling nested subdivision hierarchies recursively
+- Upserting subdivisions (create or update)
+- Error handling with logging and graceful continuation
+- Rate limiting API requests
+- Initial implementation for Portugal and Spain
+- Saving API fixtures for testing and type identification
+
+**Out of Scope:**
+- Fetching subdivisions for all countries (start with PT and ES)
+- Creating a generic Service layer (follow existing Action pattern)
+- Background job processing (synchronous during installation)
+- User interface for managing subdivisions
+- Manual subdivision management features
+- Subdivision validation beyond what API provides
+
+### Technical Considerations
+- Integration point: InstallCommand with second `spin()` block
+- API: OpenHolidays API for subdivision data
+- HTTP Client: Saloon (already in use for countries)
+- Data structure: `CreateCountrySubdivisionData` with nested children collection
+- Existing action: `CreateRootCountrySubdivision` handles recursive nesting in transactions
+- Need to create: Adapter/mapper from API response to Data objects
+- Need to create: Type mapping configuration for subdivision types
+- Need to create: Upsert action for subdivisions (or update existing CreateCountrySubdivision)
+- Testing strategy: Save API responses as fixtures to identify all subdivision types
+- Error handling: Log and continue (don't halt installation)
+- Rate limiting: Implement delays between requests
+- Database: Use transactions for data integrity (follow CreateRootCountrySubdivision pattern)

--- a/agent-os/specs/2025-10-30-fetch-country-subdivisions/spec.md
+++ b/agent-os/specs/2025-10-30-fetch-country-subdivisions/spec.md
@@ -1,0 +1,128 @@
+# Specification: Fetch Country Subdivisions from OpenHolidays API
+
+## Goal
+Integrate subdivision fetching from OpenHolidays API into the InstallCommand to populate CountrySubdivision records for Portugal and Spain, supporting nested hierarchies and standardized type mapping.
+
+## User Stories
+- As a system administrator, I want subdivisions automatically fetched during installation so that the application has geographic hierarchy data available
+- As a developer, I want subdivision data properly mapped and typed so that the system can accurately represent administrative divisions
+
+## Specific Requirements
+
+**API Integration with OpenHolidays**
+- Use existing `GetSubdivisionsRequest` Saloon request for fetching subdivision data
+- Leverage `OpenHolidaysConnector` with configured timeouts, caching, and error handling
+- Pass country ISO code (PT, ES) as query parameter to API endpoint `/Subdivisions`
+- Handle API responses containing nested subdivision hierarchies with unlimited depth
+- Use existing Saloon caching mechanism (30-day TTL) to avoid repeated API calls
+
+**InstallCommand Integration Point**
+- Add second `spin()` block after countries are seeded in `InstallCommand::handle()`
+- Execute synchronously during installation (no background jobs)
+- Display progress message: "Fetching country subdivisions..."
+- Only fetch subdivisions for Portugal (PT) and Spain (ES) initially
+- Retrieve Country models from database to get country IDs for subdivision association
+
+**Adapter Pattern for API Response Mapping**
+- Create `OpenHolidaysSubdivisionAdapter` following pattern from `OpenHolidaysHolidayAdapter`
+- Implement contract/interface defining `toCreateData()` method signature
+- Map `OpenHolidaysSubdivisionData` to `CreateCountrySubdivisionData` with nested children
+- Handle optional fields: officialLanguages (parse comma-separated or inherit from country)
+- Preserve full ISO code format (e.g., "PT-11") in both `code` and `isoCode` fields
+- Recursively transform nested children maintaining hierarchy structure
+
+**Subdivision Type Mapping Configuration**
+- Create enum mapping like app/Enums/Integrations/OpenHolidays/OpenHolidaysHolidayType.php OpenHolidays API type strings to `CountrySubdivisionType` enum
+- Strategy: collect API responses as Saloon fixtures during testing to identify all type variations
+- Store fixtures in `tests/Fixtures/Saloon/OpenHolidays/` directory following existing pattern
+- Map common types: district, region, municipality, parish, community, province, etc.
+- Default to sensible fallback type when API provides unmapped type string
+
+**Official Languages Handling**
+- Check if subdivision's `officialLanguages` field is empty/null in API response
+- Parse comma-separated language codes when provided (e.g., "pt,es" becomes ["pt", "es"])
+- Inherit from parent country's `official_languages` array when subdivision has no specific languages
+- Store as array matching `CountrySubdivision` model's `official_languages` cast
+
+**Orchestration Pattern with CreateRootCountrySubdivision**
+- Use existing `CreateRootCountrySubdivision` action to orchestrate the entire process
+- Action handles DB transactions, recursive processing, and parent-child relationships automatically
+- Pass `CreateCountrySubdivisionData` with nested children collection to the action
+- Action strips children before creating parent, then recursively processes children
+- Each subdivision saved via `CreateCountrySubdivision` action (low-level persistence)
+- No manual hierarchy flattening or ISO code tracking needed - orchestrator handles everything
+- Support unlimited nesting levels as provided by API response
+
+**Error Handling and Resilience**
+- Wrap each country's subdivision fetch in try-catch block
+- Log errors using Laravel's logging system with context (country ISO, exception message)
+- Continue processing remaining countries when one fails (skip and proceed)
+- Don't halt entire InstallCommand execution on subdivision fetch failures
+- Provide meaningful error messages for debugging API issues
+
+**Rate Limiting Implementation**
+- Add configurable delay between API requests to avoid rate limits
+- Use `sleep()` or Laravel's rate limiting helpers between country requests
+- Configure delay in `config/openholidays.php` (suggested: 500ms-1000ms between requests)
+- Consider existing caching mechanism reduces need for aggressive rate limiting
+
+**Testing Strategy with Fixtures**
+- Save API responses to `tests/Fixtures/Saloon/OpenHolidays/portugal-subdivisions.json`
+- Save API responses to `tests/Fixtures/Saloon/OpenHolidays/spain-subdivisions.json`
+- Analyze fixture responses to identify all subdivision type strings used
+- Create comprehensive type mapping based on fixture analysis
+- Write unit tests for adapter using fixture data
+- Write feature test for InstallCommand including subdivision fetching
+
+## Visual Design
+
+No visual assets provided for this feature.
+
+## Existing Code to Leverage
+
+**`app/Console/Commands/InstallCommand.php`**
+- Follow existing `spin()` pattern for visual feedback during long operations
+- Inject new action via dependency injection in `handle()` method signature
+- Add second spin block after country seeding completes
+- Maintain consistent error handling approach with existing command structure
+
+**`app/Actions/CountrySubdivision/CreateRootCountrySubdivision.php`** (Orchestration)
+- This action orchestrates the entire subdivision creation process
+- Handles DB transactions automatically via `DB::transaction()`
+- Strips children from parent data before creating parent subdivision
+- Recursively processes children via private `createChildren()` method
+- Automatically sets `countrySubdivisionId` (parent_id) for child relationships
+- Calls `CreateCountrySubdivision` action for each subdivision persistence
+- Supports unlimited nesting depth through recursion
+
+**`app/Actions/CountrySubdivision/CreateCountrySubdivision.php`** (Persistence)
+- Low-level action that saves single subdivision to database
+- Called by `CreateRootCountrySubdivision` for each subdivision in hierarchy
+- Currently uses `create()` - **may need to be updated to `updateOrCreate()` for upsert support**
+- Upsert should match on `iso_code` field to support re-running installation
+- **Investigation needed**: Check if `iso_code` has unique constraint in database
+
+**`app/Http/Integrations/OpenHolidays/Requests/GetSubdivisionsRequest.php`**
+- Use existing Saloon request with `countryIsoCode` parameter
+- Leverage built-in caching (30-day TTL) and Laravel cache driver
+- Request already configured with proper endpoint `/Subdivisions`
+- Optional `languageIsoCode` parameter available if needed
+
+**`app/Http/Integrations/OpenHolidays/Adapters/OpenHolidaysHolidayAdapter.php`**
+- Follow adapter pattern structure: implement interface with `toCreateData()` method
+- Transform external API data object to internal Data object format
+- Handle nullable/optional fields with safe navigation and defaults
+- Use helper methods from Data objects for localized content
+
+## Out of Scope
+
+- Fetching subdivisions for countries other than Portugal and Spain
+- Creating generic Service layer architecture (use Action pattern per existing conventions)
+- Background job processing or queue-based subdivision fetching
+- User interface for viewing, managing, or editing subdivisions manually
+- Subdivision validation rules beyond what OpenHolidays API provides
+- Custom subdivision creation or modification features
+- Subdivision search or filtering functionality
+- Exporting subdivision data to external formats
+- Webhook or event-driven subdivision updates from external sources
+- Multi-language subdivision name translation beyond API-provided data

--- a/agent-os/specs/2025-10-30-fetch-country-subdivisions/tasks.md
+++ b/agent-os/specs/2025-10-30-fetch-country-subdivisions/tasks.md
@@ -1,0 +1,382 @@
+# Task Breakdown: Fetch Country Subdivisions from OpenHolidays API
+
+## Overview
+Total Task Groups: 6
+Total Tasks: 25
+
+This feature integrates OpenHolidays API subdivision fetching into the InstallCommand to automatically populate CountrySubdivision records for Portugal and Spain during installation, with proper type mapping, nested hierarchy support, and error handling.
+
+## Task List
+
+### Phase 1: Configuration & Setup
+
+#### Task Group 1: Type Mapping Configuration & Upsert Investigation
+**Dependencies:** None
+
+- [ ] 1.0 Complete subdivision type mapping configuration and upsert investigation
+  - [ ] 1.1 Investigate CreateCountrySubdivision for upsert support
+    - Check if `iso_code` has unique constraint in `country_subdivisions` table
+    - Review if `CreateCountrySubdivision` needs updating from `create()` to `updateOrCreate()`
+    - If upsert needed, match on `iso_code` field
+    - Write 1-2 tests for upsert behavior (create new, update existing)
+    - Update action if necessary to support re-running installation
+  - [ ] 1.2 Write 2-4 focused tests for OpenHolidaysSubdivisionType enum
+    - Test transform() method maps to correct CountrySubdivisionType
+    - Test fallback/default type handling
+    - Test all expected subdivision types from fixtures
+  - [ ] 1.3 Create OpenHolidaysSubdivisionType enum
+    - File: `app/Enums/Integrations/OpenHolidays/OpenHolidaysSubdivisionType.php`
+    - Follow pattern from OpenHolidaysHolidayType.php
+    - Add cases: District, Region, Municipality, Parish, Community, Province
+    - Implement transform() method returning CountrySubdivisionType
+    - Add sensible fallback for unmapped types (default to District)
+    - Note: Additional types will be discovered during fixture analysis
+  - [ ] 1.4 Add rate limiting configuration to config/openholidays.php
+    - Add 'rate_limit' array with 'delay_ms' key (default: 500)
+    - Document purpose: prevent API rate limiting between country requests
+    - Place in configuration alongside existing cache settings
+  - [ ] 1.5 Ensure type mapping tests pass
+    - Run ONLY the 2-4 tests written in 1.1
+    - Verify enum cases map correctly to CountrySubdivisionType
+    - Do NOT run entire test suite at this stage
+
+**Acceptance Criteria:**
+- OpenHolidaysSubdivisionType enum created with transform() method
+- The 2-4 tests written in 1.1 pass
+- Rate limiting configuration added to config file
+- Enum follows existing OpenHolidaysHolidayType pattern
+
+**Technical Notes:**
+- Subdivision type mapping may need updates after analyzing API fixtures in Phase 5
+- Rate limit delay should be configurable for different environments
+
+---
+
+### Phase 2: API Data Adapter
+
+#### Task Group 2: Subdivision Adapter Implementation
+**Dependencies:** Task Group 1
+
+- [ ] 2.0 Complete API data adapter
+  - [ ] 2.1 Write 2-6 focused tests for OpenHolidaysSubdivisionAdapter
+    - Test toCreateData() transforms simple subdivision correctly
+    - Test nested children are recursively transformed
+    - Test official languages parsing (comma-separated to array)
+    - Test official languages inheritance from country when empty
+    - Test full ISO code preservation in both code and isoCode fields
+  - [ ] 2.2 Create SubdivisionAdapter contract/interface
+    - File: `app/Contracts/SubdivisionAdapter.php`
+    - Follow pattern from HolidayAdapter contract
+    - Define toCreateData() method signature
+    - Accept OpenHolidaysSubdivisionData, countryId, and country languages
+    - Return CreateCountrySubdivisionData
+  - [ ] 2.3 Implement OpenHolidaysSubdivisionAdapter
+    - File: `app/Http/Integrations/OpenHolidays/Adapters/OpenHolidaysSubdivisionAdapter.php`
+    - Implement SubdivisionAdapter interface
+    - Map OpenHolidaysSubdivisionData to CreateCountrySubdivisionData
+    - Parse officialLanguages: split comma-separated string to array
+    - Inherit parent country languages when subdivision languages empty/null
+    - Preserve full ISO code (e.g., "PT-11") in both code and isoCode
+    - Use getLocalizedName() for name array transformation
+    - Recursively transform children maintaining hierarchy
+    - Inject CreateCountrySubdivisionData for nested children
+  - [ ] 2.4 Add helper method for language parsing
+    - Private method parseOfficialLanguages(string|null, array)
+    - Split comma-separated languages or return country default
+    - Handle null/empty cases gracefully
+  - [ ] 2.5 Add helper method for recursive children transformation
+    - Private method transformChildren(array|null, int, array)
+    - Return Collection<int, CreateCountrySubdivisionData>|null
+    - Recursively process nested subdivisions
+    - Pass country ID and languages to children
+  - [ ] 2.6 Ensure adapter tests pass
+    - Run ONLY the 2-6 tests written in 2.1
+    - Verify transformations work correctly
+    - Do NOT run entire test suite at this stage
+
+**Acceptance Criteria:**
+- SubdivisionAdapter contract created
+- OpenHolidaysSubdivisionAdapter implements contract correctly
+- The 2-6 tests written in 2.1 pass
+- Adapter handles nested children recursively
+- Official languages parsed and inherited correctly
+- Full ISO codes preserved
+
+**Technical Notes:**
+- Adapter pattern reuses from OpenHolidaysHolidayAdapter structure
+- Language inheritance ensures subdivisions always have valid language data
+- Recursive transformation maintains unlimited nesting depth
+
+---
+
+### Phase 3: InstallCommand Integration
+
+#### Task Group 3: Command Integration with CreateRootCountrySubdivision
+**Dependencies:** Task Group 2
+
+- [ ] 3.0 Complete InstallCommand integration
+  - [ ] 3.1 Write 2-4 focused tests for InstallCommand subdivision fetching
+    - Test subdivisions fetched for Portugal and Spain
+    - Test progress message displayed: "Fetching country subdivisions..."
+    - Test graceful handling when API fails for one country
+    - Test rate limiting delay applied between requests
+  - [ ] 3.2 Update InstallCommand handle() method
+    - File: `app/Console/Commands/InstallCommand.php`
+    - Inject CreateRootCountrySubdivision action via constructor
+    - Inject OpenHolidaysSubdivisionAdapter via constructor
+    - Inject OpenHolidaysConnector via constructor
+    - Add second spin() block after country seeding
+    - Spin message: "Fetching country subdivisions..."
+  - [ ] 3.3 Implement subdivision fetching logic
+    - Iterate over ['PT', 'ES'] country ISO codes
+    - Retrieve Country model from database to get country ID and languages
+    - Create GetSubdivisionsRequest with country ISO code
+    - Send request via OpenHolidaysConnector->send()
+    - Parse JSON response to get array/collection of root subdivisions
+    - For each root subdivision from API:
+      - Transform using adapter->toCreateData() (returns CreateCountrySubdivisionData with nested children)
+      - Call CreateRootCountrySubdivision->handle() passing the transformed data
+      - Orchestrator handles ALL recursion, transactions, and persistence automatically
+  - [ ] 3.4 Apply rate limiting between country requests
+    - Use config('openholidays.rate_limit.delay_ms', 500)
+    - Call usleep(delay * 1000) between country iterations
+    - Skip delay on last country to avoid unnecessary wait
+  - [ ] 3.5 Wrap each country fetch in try-catch
+    - Catch Throwable to handle API errors gracefully
+    - Log error with context: country ISO, exception message
+    - Continue processing next country on failure
+    - Use Log::error() with structured context array
+  - [ ] 3.6 Ensure InstallCommand tests pass
+    - Run ONLY the 2-4 tests written in 3.1
+    - Verify integration works correctly
+    - Do NOT run entire test suite at this stage
+
+**Acceptance Criteria:**
+- The 2-4 tests written in 3.1 pass
+- InstallCommand has second spin block for subdivisions
+- Subdivisions fetched only for Portugal and Spain
+- CreateRootCountrySubdivision orchestrates the entire process
+- Rate limiting applied between API requests
+- Errors logged and processing continues for other countries
+- Progress feedback provided to user
+
+**Technical Notes:**
+- CreateRootCountrySubdivision handles DB transactions and recursion
+- Adapter transforms API data to CreateCountrySubdivisionData
+- No new upsert action needed - CreateRootCountrySubdivision uses CreateCountrySubdivision
+- Error handling ensures installation doesn't fail on API issues
+
+---
+
+### Phase 4: Error Handling & Logging
+
+#### Task Group 4: Robust Error Management
+**Dependencies:** Task Group 3
+
+- [ ] 4.0 Complete error handling and logging
+  - [ ] 4.1 Write 2-4 focused tests for error scenarios
+    - Test API connection failure logs error and continues
+    - Test invalid JSON response logs error and continues
+    - Test missing country in database logs error and continues
+    - Test all errors include proper context (country ISO, message)
+  - [ ] 4.2 Enhance error logging with structured context
+    - Log level: error
+    - Context: country ISO code, exception message, exception class
+    - Message format: "Failed to fetch subdivisions for {countryIsoCode}"
+    - Include stack trace for debugging
+  - [ ] 4.3 Add defensive null checks
+    - Verify Country model exists before fetching subdivisions
+    - Verify API response is not empty before processing
+    - Verify subdivision data has required fields before transforming
+    - Skip invalid subdivisions gracefully with warning logs
+  - [ ] 4.4 Ensure error handling tests pass
+    - Run ONLY the 2-4 tests written in 4.1
+    - Verify errors are caught and logged correctly
+    - Do NOT run entire test suite at this stage
+
+**Acceptance Criteria:**
+- The 2-4 tests written in 4.1 pass
+- All error scenarios logged with proper context
+- Defensive null checks prevent unexpected crashes
+- Processing continues for other countries on errors
+- Warning logs for skipped invalid subdivisions
+
+**Technical Notes:**
+- Error handling ensures installation robustness
+- Structured logging aids debugging in production
+- Graceful degradation: partial success is acceptable
+
+---
+
+### Phase 5: Testing with Saloon Fixtures
+
+#### Task Group 5: Comprehensive Test Coverage with Fixtures
+**Dependencies:** Task Groups 1-4
+
+- [ ] 5.0 Complete testing with Saloon fixtures and fill critical gaps only
+  - [ ] 5.1 Review existing tests from Task Groups 1-4
+    - Review the 2-4 tests written for type mapping (Task 1.1)
+    - Review the 2-6 tests written for adapter (Task 2.1)
+    - Review the 2-4 tests written for InstallCommand (Task 3.1)
+    - Review the 2-4 tests written for error handling (Task 4.1)
+    - Total existing tests: approximately 8-18 tests
+  - [ ] 5.2 Fetch and save API responses as Saloon fixtures
+    - Create test script to fetch real API responses
+    - File: `tests/Fixtures/Saloon/OpenHolidays/portugal-subdivisions.json`
+    - File: `tests/Fixtures/Saloon/OpenHolidays/spain-subdivisions.json`
+    - Use GetSubdivisionsRequest with PT and ES country codes
+    - Save raw JSON responses maintaining structure
+    - Analyze responses to identify all subdivision type strings
+  - [ ] 5.3 Update OpenHolidaysSubdivisionType enum based on fixtures
+    - Review fixture data for actual subdivision type strings
+    - Add missing enum cases discovered in fixtures
+    - Update transform() method to map all discovered types
+    - Document any unknown types in code comments
+    - Update tests to cover newly discovered types
+  - [ ] 5.4 Analyze test coverage gaps for THIS feature only
+    - Identify critical workflows lacking test coverage
+    - Focus ONLY on gaps related to subdivision fetching feature
+    - Prioritize end-to-end workflows over unit test gaps
+    - Do NOT assess entire application test coverage
+  - [ ] 5.5 Write up to 6 additional strategic tests maximum
+    - Add maximum of 6 new tests to fill identified critical gaps
+    - Focus on integration points and end-to-end workflows
+    - Test with fixture data for realistic scenarios
+    - Test nested hierarchy creation with multiple levels
+    - Test subdivision upsert behavior on repeated runs
+    - Skip edge cases, performance tests unless business-critical
+  - [ ] 5.6 Run feature-specific tests only
+    - Run ONLY tests related to subdivision fetching feature
+    - Expected total: approximately 14-24 tests maximum
+    - Do NOT run entire application test suite
+    - Verify all critical workflows pass
+
+**Acceptance Criteria:**
+- Portugal and Spain subdivision fixtures saved successfully
+- OpenHolidaysSubdivisionType enum updated with all discovered types
+- All feature-specific tests pass (approximately 14-24 tests total)
+- Critical workflows covered with realistic fixture data
+- No more than 6 additional tests added when filling gaps
+- Testing focused exclusively on subdivision fetching feature
+
+**Technical Notes:**
+- Fixtures provide realistic test data and document API structure
+- Type mapping completeness depends on fixture analysis
+- Feature tests use fixtures for deterministic, fast testing
+- Saloon's caching mechanism helps with fixture management
+
+---
+
+### Phase 6: Documentation
+
+#### Task Group 6: Code Documentation
+**Dependencies:** Task Group 5
+
+- [ ] 6.0 Complete code documentation
+  - [ ] 6.1 Document OpenHolidaysSubdivisionType enum
+    - Add PHPDoc block explaining purpose
+    - Document each enum case with country examples
+    - Document transform() method behavior
+    - Document fallback strategy for unknown types
+  - [ ] 6.2 Document OpenHolidaysSubdivisionAdapter class
+    - Add class-level PHPDoc explaining adapter pattern
+    - Document toCreateData() method parameters and return
+    - Document private helper methods
+    - Add inline comments for complex transformations
+  - [ ] 6.3 Document InstallCommand subdivision integration
+    - Add inline comments explaining subdivision fetching flow
+    - Document error handling strategy
+    - Document rate limiting implementation
+    - Add comments explaining CreateRootCountrySubdivision usage
+  - [ ] 6.4 Update config/openholidays.php documentation
+    - Document rate_limit configuration options
+    - Explain rate limiting purpose and recommended values
+    - Add examples for different environments
+  - [ ] 6.5 Create type mapping reference document
+    - File: `agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/subdivision-type-mapping.md`
+    - List all OpenHolidays API subdivision types discovered
+    - Map each to corresponding CountrySubdivisionType
+    - Document any unmapped types and fallback strategy
+    - Include examples from Portugal and Spain
+
+**Acceptance Criteria:**
+- All new classes have comprehensive PHPDoc blocks
+- Complex logic has inline comments for clarity
+- Configuration options documented with examples
+- Type mapping reference document created
+- Documentation follows existing codebase conventions
+
+**Technical Notes:**
+- Documentation aids future maintenance and debugging
+- Type mapping reference helps understand API variations
+- Clear comments reduce cognitive load for developers
+
+---
+
+## Execution Order
+
+Recommended implementation sequence:
+1. **Phase 1: Configuration & Setup** (Task Group 1) - No dependencies, foundational setup
+2. **Phase 2: API Data Adapter** (Task Group 2) - Depends on type mapping configuration
+3. **Phase 3: InstallCommand Integration** (Task Group 3) - Depends on adapter being ready
+4. **Phase 4: Error Handling & Logging** (Task Group 4) - Depends on basic integration working
+5. **Phase 5: Testing with Fixtures** (Task Group 5) - Depends on all implementation complete
+6. **Phase 6: Documentation** (Task Group 6) - Final step after everything works
+
+## Key Technical Decisions
+
+**Action Pattern Architecture:**
+- `CreateRootCountrySubdivision` - Orchestrates the entire process (handles recursion, hierarchy, transactions)
+- `CreateCountrySubdivision` - Low-level persistence (saves single subdivision to database)
+- No new upsert action needed - existing actions handle all requirements
+
+**Implementation Flow:**
+```
+InstallCommand (spin block #2)
+  → Iterate PT, ES countries
+  → Fetch from OpenHolidays API (GetSubdivisionsRequest)
+  → OpenHolidaysSubdivisionAdapter transforms to CreateCountrySubdivisionData
+  → Call CreateRootCountrySubdivision (orchestrates entire hierarchy)
+    → Strips children from parent data
+    → Calls CreateCountrySubdivision (saves parent to DB)
+    → Recursively processes children via createChildren()
+      → For each child, strips grandchildren
+      → Calls CreateCountrySubdivision (saves child with parent_id)
+      → Recursively processes grandchildren
+  → Rate limiting delay between countries
+  → Error handling per country with logging
+```
+
+**Critical Integration Points:**
+- InstallCommand integrates after country seeding completes
+- Adapter transforms nested API data to nested CreateCountrySubdivisionData
+- CreateRootCountrySubdivision handles DB transactions and recursion automatically
+- Error handling ensures installation robustness
+
+**Testing Strategy:**
+- Limit test writing during development: 2-6 tests per task group
+- Focus on critical behaviors only during development
+- Use Saloon fixtures for realistic, deterministic testing
+- Gap analysis in Phase 5 adds maximum 6 additional strategic tests
+- Total expected tests: approximately 14-24 tests for entire feature
+- Run only feature-specific tests, not entire suite
+
+## Files to Create/Modify
+
+**New Files:**
+- `app/Enums/Integrations/OpenHolidays/OpenHolidaysSubdivisionType.php`
+- `app/Contracts/SubdivisionAdapter.php`
+- `app/Http/Integrations/OpenHolidays/Adapters/OpenHolidaysSubdivisionAdapter.php`
+- `tests/Fixtures/Saloon/OpenHolidays/portugal-subdivisions.json`
+- `tests/Fixtures/Saloon/OpenHolidays/spain-subdivisions.json`
+- `agent-os/specs/2025-10-30-fetch-country-subdivisions/planning/subdivision-type-mapping.md`
+
+**Modified Files:**
+- `app/Console/Commands/InstallCommand.php` - Add second spin block for subdivision fetching
+- `config/openholidays.php` - Add rate limiting configuration
+
+**Test Files:**
+- `tests/Unit/Enums/Integrations/OpenHolidays/OpenHolidaysSubdivisionTypeTest.php`
+- `tests/Unit/Http/Integrations/OpenHolidays/Adapters/OpenHolidaysSubdivisionAdapterTest.php`
+- `tests/Feature/Console/Commands/InstallCommandTest.php` - Add subdivision fetching tests
+- Additional strategic tests as needed in Phase 5

--- a/agent-os/specs/2025-10-30-fetch-country-subdivisions/verification/spec-verification.md
+++ b/agent-os/specs/2025-10-30-fetch-country-subdivisions/verification/spec-verification.md
@@ -1,0 +1,436 @@
+# Specification Verification Report
+
+## Verification Summary
+- Overall Status: FAILED - Critical architectural misalignment
+- Date: 2025-10-30
+- Spec: Fetch Country Subdivisions from OpenHolidays API
+- Reusability Check: FAILED - Incorrect Action pattern usage
+- Test Writing Limits: PASSED - Compliant with 2-8 tests per group
+
+## Structural Verification (Checks 1-2)
+
+### Check 1: Requirements Accuracy
+✅ All user answers accurately captured in requirements.md
+✅ Q1-Q10 responses correctly documented
+✅ Critical architectural clarification about Action pattern included in requirements
+✅ Reusability opportunities clearly documented:
+- CreateRootCountrySubdivision for orchestration pattern
+- CreateCountrySubdivision for persistence
+- UpsertCountrySubdivisions for upsert operations
+- OpenHolidays Saloon connector and requests
+- OpenHolidaysHolidayAdapter for adapter pattern reference
+
+### Check 2: Visual Assets
+✅ No visual files found in planning/visuals/
+✅ Requirements.md correctly indicates "No visual assets provided"
+N/A - No visual verification needed
+
+## Content Validation (Checks 3-7)
+
+### Check 3: Visual Design Tracking
+N/A - No visual assets provided for this feature
+
+### Check 4: Requirements Coverage
+
+**Explicit Features Requested:**
+- Integration as second spin() block in InstallCommand: ✅ Covered
+- Fetch only Portugal and Spain: ✅ Covered
+- Type mapping configuration: ✅ Covered
+- Nested subdivisions with CreateRootCountrySubdivision pattern: ✅ Covered
+- Skip errors and continue: ✅ Covered
+- Full ISO code: ✅ Covered
+- Parse official languages (comma-separated, default to parent): ✅ Covered
+- Implement rate limiting: ✅ Covered
+- Upsert subdivisions: ✅ Covered
+- Save API responses as Saloon fixtures: ✅ Covered
+
+**Reusability Opportunities:**
+- Reference country creation patterns: ✅ Documented in spec
+- Use CreateRootCountrySubdivision: ❌ MISUSED - See Critical Issue #1
+- Leverage CreateCountrySubdivisionData: ✅ Referenced
+- Use existing Saloon setup: ✅ Leveraged
+- Follow Action pattern: ⚠️ PARTIALLY - See Critical Issue #1
+
+**Out-of-Scope Items:**
+- Correctly excluded: All other countries, Service layer, background jobs, UI, manual management
+- Incorrectly included: None
+
+### Check 5: Core Specification Issues
+
+**Goal Alignment:**
+✅ Goal clearly addresses the user's need to fetch subdivisions during installation
+✅ Mentions Portugal and Spain specifically
+✅ References nested hierarchies and type mapping
+
+**User Stories:**
+✅ Stories are relevant to system administrator and developer needs
+✅ Aligned with initial requirements
+
+**Core Requirements:**
+✅ All 10 requirements from Q&A captured in spec.md
+✅ API integration details comprehensive
+✅ InstallCommand integration point clearly defined
+✅ Adapter pattern section included
+✅ Type mapping configuration specified
+✅ Official languages handling detailed
+❌ **CRITICAL: Upsert strategy section fundamentally wrong** - See Critical Issue #1
+✅ Nested hierarchy processing references CreateRootCountrySubdivision
+✅ Error handling strategy matches user answer
+✅ Rate limiting implementation specified
+✅ Testing strategy with fixtures included
+
+**Out of Scope:**
+✅ All items correctly match requirements.md scope boundaries
+✅ No scope creep detected
+
+**Reusability Notes:**
+✅ Spec mentions CreateRootCountrySubdivision pattern
+✅ References OpenHolidaysHolidayAdapter pattern
+✅ Lists UpsertCountrySubdivisions action
+❌ **CRITICAL: Misunderstands the architectural relationship** - See Critical Issue #1
+
+### Check 6: Task List Detailed Validation
+
+**Test Writing Limits:**
+✅ Task Group 1: 2-4 focused tests specified
+✅ Task Group 2: 2-6 focused tests specified
+✅ Task Group 3: 2-4 focused tests specified
+✅ Task Group 4: 2-4 focused tests specified
+✅ Task Group 5: Maximum 6 additional strategic tests
+✅ Test verification runs ONLY newly written tests, not entire suite
+✅ Expected total: approximately 14-24 tests (within reasonable limits)
+✅ No comprehensive/exhaustive testing called for
+
+**Reusability References:**
+✅ Task 1.2 follows OpenHolidaysHolidayType pattern
+✅ Task 2.2 follows HolidayAdapter contract pattern
+✅ Task 2.3 references OpenHolidaysHolidayAdapter structure
+✅ Task 3.2 injects CreateRootCountrySubdivision
+❌ **CRITICAL: Tasks completely bypass CreateRootCountrySubdivision's purpose** - See Critical Issue #1
+✅ Task 5.2 uses existing GetSubdivisionsRequest
+
+**Specificity:**
+✅ Each task references specific features/components
+✅ File paths provided for new files
+✅ Methods and dependencies clearly stated
+⚠️ Task 3.3 lacks critical implementation details about hierarchy flattening
+
+**Traceability:**
+✅ All tasks trace back to requirements
+✅ Phase organization logical and sequential
+✅ Dependencies clearly marked
+
+**Scope:**
+✅ No tasks for features not in requirements
+✅ Documentation task appropriately included
+
+**Visual Alignment:**
+N/A - No visual files to reference
+
+**Task Count:**
+✅ Task Group 1: 6 tasks (reasonable)
+✅ Task Group 2: 6 tasks (reasonable)
+✅ Task Group 3: 6 tasks (reasonable)
+✅ Task Group 4: 4 tasks (reasonable)
+✅ Task Group 5: 6 tasks (reasonable)
+✅ Task Group 6: 5 tasks (reasonable)
+Total: 33 subtasks across 6 task groups - appropriate granularity
+
+### Check 7: Reusability and Over-Engineering Check
+
+**Architectural Misalignment - CRITICAL:**
+
+❌ **Fundamental misunderstanding of Action orchestration pattern**
+- User clarified: "CreateRootCountrySubdivision - Orchestrates the process (handles recursion, hierarchy)"
+- User clarified: "CreateCountrySubdivision - Saves data to database (low-level persistence)"
+- Requirements.md correctly captures this relationship
+
+**What the Spec/Tasks Got Wrong:**
+1. Spec Section "Upsert Strategy for Idempotency" (lines 47-53):
+   - Proposes using UpsertCountrySubdivisions action
+   - Suggests flattening hierarchy before upserting
+   - Suggests tracking parent ISO codes to database IDs
+   - This completely bypasses CreateRootCountrySubdivision's orchestration role
+
+2. Task 3.3 "Implement subdivision fetching logic":
+   - States: "Call CreateRootCountrySubdivision->handle() for each root subdivision"
+   - BUT the adapter transforms to CreateCountrySubdivisionData
+   - This creates confusion: Are we using CreateRoot for orchestration or direct insertion?
+
+3. Key Implementation Flow (lines 325-341):
+   - Shows CreateRootCountrySubdivision being called
+   - BUT earlier spec says to use UpsertCountrySubdivisions
+   - Contradictory approach within same document
+
+**What Should Happen (Per User's Architecture):**
+- InstallCommand fetches API data
+- Adapter transforms API → CreateCountrySubdivisionData (with nested children)
+- CreateRootCountrySubdivision orchestrates the ENTIRE process:
+  - Determines if subdivision exists (via iso_code check)
+  - Uses CreateCountrySubdivision for actual DB insert/update
+  - Recursively handles all children
+  - Manages transactions
+- NO need for separate upsert logic in InstallCommand
+- NO need to flatten hierarchy
+- NO need to track ISO codes to IDs manually
+
+**Unnecessary New Components:**
+❌ The spec introduces unnecessary complexity with UpsertCountrySubdivisions usage
+- CreateRootCountrySubdivision should handle all orchestration
+- CreateCountrySubdivision likely already handles upsert logic OR should be enhanced
+- Flattening hierarchy defeats the purpose of recursive orchestration
+
+**Missing Reuse Opportunities:**
+❌ Not leveraging CreateRootCountrySubdivision's full orchestration capabilities
+- User specifically mentioned looking at this action as reference
+- Action's purpose is to orchestrate the entire hierarchy creation
+- Should be the ONLY action called from InstallCommand
+
+**Justification Issues:**
+❌ No clear reasoning for bypassing CreateRootCountrySubdivision's orchestration
+❌ Spec introduces UpsertCountrySubdivisions without explaining why CreateRoot can't handle it
+❌ Tasks don't clarify the architectural decision to flatten vs. orchestrate
+
+## Critical Issues
+[Issues that MUST be fixed before implementation]
+
+### 1. ARCHITECTURAL MISALIGNMENT - Action Pattern Violation
+**Severity:** CRITICAL - Blocks implementation
+**Location:** spec.md lines 47-53, tasks.md Task 3.3
+
+**Problem:**
+The spec and tasks fundamentally misunderstand the Action pattern architecture that the user clarified:
+
+**User's Architecture (CORRECT):**
+```
+CreateRootCountrySubdivision → Orchestrates process (recursion, hierarchy, upsert logic)
+CreateCountrySubdivision → Saves data to database (low-level persistence)
+```
+
+**What Spec Proposes (WRONG):**
+```
+InstallCommand → Flattens hierarchy → UpsertCountrySubdivisions
+OR
+InstallCommand → CreateRootCountrySubdivision (but unclear what it does with upsert)
+```
+
+**Why This is Critical:**
+- Completely bypasses the orchestration layer the user designed
+- Introduces manual hierarchy tracking that CreateRootCountrySubdivision handles
+- Creates confusion about which action does what
+- May result in duplicate code or skipped functionality
+- Violates the "look at CreateRootCountrySubdivision" guidance from user
+
+**Required Fix:**
+1. Remove "Upsert Strategy for Idempotency" section (spec.md lines 47-53)
+2. Clarify that CreateRootCountrySubdivision handles ALL hierarchy processing including upsert logic
+3. InstallCommand should ONLY:
+   - Fetch API data
+   - Transform via adapter
+   - Call CreateRootCountrySubdivision->handle()
+   - Let orchestration layer handle everything else
+4. Verify if CreateCountrySubdivision supports upsert, or if CreateRootCountrySubdivision needs enhancement
+5. Update tasks to reflect simplified flow: fetch → transform → orchestrate (no manual flattening)
+
+**Impact:**
+- Without this fix, implementation will either duplicate functionality or bypass critical orchestration logic
+- Tests will not reflect actual architectural patterns
+- Future maintainers will be confused by contradictory approaches
+
+### 2. Unclear Upsert Implementation Strategy
+**Severity:** CRITICAL - Ambiguous requirements
+**Location:** spec.md line 49, tasks.md Task 3.3
+
+**Problem:**
+The spec mentions using UpsertCountrySubdivisions with InsertCountrySubdivisionData, but:
+- CreateRootCountrySubdivision uses CreateCountrySubdivisionData
+- User said "we upsert them" but didn't specify which action handles it
+- Spec doesn't clarify if CreateCountrySubdivision already supports upsert
+- Tasks don't explain the upsert mechanism
+
+**Required Clarification:**
+1. Does CreateCountrySubdivision already handle upsert logic?
+2. If not, should we enhance it or use UpsertCountrySubdivisions?
+3. If using UpsertCountrySubdivisions, how does it integrate with CreateRootCountrySubdivision's orchestration?
+4. What is InsertCountrySubdivisionData vs CreateCountrySubdivisionData?
+
+**Recommended Approach:**
+- Check existing CreateCountrySubdivision implementation
+- If it only inserts, enhance it to upsert based on iso_code
+- Keep orchestration in CreateRootCountrySubdivision
+- Avoid introducing additional actions that bypass orchestration
+
+## Minor Issues
+[Issues that should be addressed but don't block progress]
+
+### 1. Missing Implementation Details in Task 3.3
+**Severity:** Minor
+**Location:** tasks.md lines 125-131
+
+**Issue:**
+Task 3.3 says "Call CreateRootCountrySubdivision->handle() for each root subdivision" but doesn't clarify:
+- How many root subdivisions per country?
+- Does API return array of roots or single root with children?
+- Should we iterate over roots or pass entire collection?
+
+**Recommendation:**
+Add clarification after analyzing API response structure in Phase 5
+
+### 2. Rate Limiting Configuration Placement
+**Severity:** Minor
+**Location:** tasks.md line 1.3
+
+**Issue:**
+Task 1.3 suggests adding to existing config file, but doesn't specify exact structure or example
+
+**Recommendation:**
+Provide example configuration structure in task:
+```php
+'rate_limit' => [
+    'delay_ms' => env('OPENHOLIDAYS_RATE_LIMIT_MS', 500),
+],
+```
+
+### 3. Documentation Task Creates Planning Document
+**Severity:** Minor
+**Location:** tasks.md lines 287-292
+
+**Issue:**
+Task 6.5 creates `subdivision-type-mapping.md` in planning/ folder, but:
+- Planning phase is complete
+- This is implementation documentation
+- Should be in docs/ or similar location
+
+**Recommendation:**
+Either remove this task or move document to appropriate location (e.g., docs/ or inline code comments)
+
+### 4. Fixture Saving Process Not Specified
+**Severity:** Minor
+**Location:** tasks.md lines 5.2
+
+**Issue:**
+Task says "Create test script to fetch real API responses" but doesn't specify:
+- Should this be a command, test, or manual script?
+- When should it run (during development, in CI, manually)?
+- How to handle API failures during fixture generation?
+
+**Recommendation:**
+Clarify this is a one-time manual development task, not automated testing
+
+## Over-Engineering Concerns
+[Features/complexity added beyond requirements]
+
+### 1. Unnecessary UpsertCountrySubdivisions Integration
+**Severity:** Moderate
+**Location:** spec.md lines 47-53, spec.md lines 100-104
+
+**Issue:**
+Spec introduces complexity with UpsertCountrySubdivisions that may not be needed:
+- User said to use CreateRootCountrySubdivision pattern
+- Orchestration should handle upsert logic internally
+- Flattening hierarchy defeats purpose of recursive orchestration
+- Adds manual parent ID tracking that should be automated
+
+**Why This is Over-Engineering:**
+- User's requirement: "we upsert them" - doesn't specify HOW
+- Existing CreateRootCountrySubdivision may already handle this
+- Adding another action layer bypasses orchestration pattern
+- Increases complexity without clear benefit
+
+**Recommendation:**
+- Keep it simple: Use CreateRootCountrySubdivision as orchestrator
+- Enhance CreateCountrySubdivision to support upsert if needed
+- Don't introduce flattening logic unless orchestration can't handle it
+
+### 2. Premature Type Mapping Optimization
+**Severity:** Low
+**Location:** tasks.md lines 16-27
+
+**Issue:**
+Task 1.2 defines specific subdivision types (District, Region, Municipality, etc.) before analyzing actual API responses
+- User said strategy is to collect fixtures FIRST, then identify types
+- Spec defines types before fixtures are analyzed
+- May result in incorrect mappings or rework
+
+**Why This is Over-Engineering:**
+- Guessing types before seeing data
+- User's strategy: fixtures first, types second
+- May need complete rework after fixture analysis
+
+**Recommendation:**
+- Create minimal enum with just "Unknown" type first
+- Analyze fixtures in Phase 5
+- Add actual types discovered from real data
+- This matches user's stated strategy
+
+### 3. Complex Language Parsing Logic
+**Severity:** Low
+**Location:** spec.md lines 41-45, tasks.md lines 78-80
+
+**Issue:**
+Spec describes comma-separated parsing AND inheritance logic, but:
+- User said "parse comma-separated list, default to parent"
+- May be simpler in practice (API might always provide array)
+- Won't know until we see fixture data
+
+**Why This Might Be Over-Engineering:**
+- Anticipating complexity before seeing actual API response format
+- May be simpler than expected
+
+**Recommendation:**
+- Implement minimal version first
+- Enhance after analyzing fixture data
+- User's answer suggests straightforward approach
+
+## Recommendations
+
+### MUST FIX (Critical)
+1. **Remove UpsertCountrySubdivisions from spec** - This bypasses orchestration
+2. **Clarify CreateRootCountrySubdivision handles ALL hierarchy processing including upsert**
+3. **Simplify InstallCommand flow**: fetch → transform → call CreateRootCountrySubdivision
+4. **Investigate if CreateCountrySubdivision supports upsert or needs enhancement**
+5. **Update Task 3.3 to remove hierarchy flattening logic**
+6. **Add section explaining why CreateRootCountrySubdivision is the orchestrator**
+
+### SHOULD FIX (Minor)
+7. Add clarification to Task 3.3 about root subdivision iteration
+8. Provide example configuration structure for rate limiting
+9. Relocate or remove subdivision-type-mapping.md from planning folder
+10. Clarify fixture generation is one-time manual development task
+
+### CONSIDER (Over-Engineering)
+11. Start with minimal enum types, add after fixture analysis (matches user strategy)
+12. Implement minimal language parsing first, enhance after seeing fixtures
+13. Remove premature complexity around upsert strategy until we confirm what exists
+
+## Conclusion
+
+**Status: NOT READY FOR IMPLEMENTATION - REQUIRES SIGNIFICANT REVISION**
+
+### Critical Blocker
+The specification and tasks fundamentally misunderstand the Action pattern architecture that the user clarified. The spec introduces unnecessary complexity by suggesting UpsertCountrySubdivisions and hierarchy flattening, which completely bypasses the CreateRootCountrySubdivision orchestration layer that the user specifically designed and referenced.
+
+### What's Working Well
+- Requirements accurately capture all user answers
+- Test writing limits properly followed (2-8 tests per group, 14-24 total)
+- Comprehensive coverage of error handling and rate limiting
+- Good use of existing patterns (adapter, Saloon, fixtures)
+- Appropriate scope boundaries
+- No scope creep detected
+
+### What Must Change
+1. **Remove all references to flattening hierarchy manually**
+2. **Clarify CreateRootCountrySubdivision is the ONLY orchestration point**
+3. **Simplify InstallCommand to: fetch → transform → orchestrate**
+4. **Verify upsert capability in CreateCountrySubdivision or document enhancement needs**
+5. **Update all tasks to reflect simplified orchestration-first architecture**
+
+### Next Steps Before Implementation
+1. Revise spec.md to remove "Upsert Strategy for Idempotency" section
+2. Add "Orchestration Pattern" section explaining CreateRootCountrySubdivision's role
+3. Update tasks.md Task 3.3 to remove manual hierarchy tracking
+4. Read CreateCountrySubdivision source to confirm upsert capability
+5. Update Implementation Flow diagram to show orchestration-first approach
+6. Re-verify alignment with user's architectural clarification
+
+Once these critical issues are resolved, the spec will accurately reflect the user's requirements and architectural decisions.

--- a/agent-os/standards/backend/actions.md
+++ b/agent-os/standards/backend/actions.md
@@ -1,0 +1,16 @@
+## Action class standards
+
+- **Action Pattern**: Use Action classes in `app/Actions/` for ALL business logic - keep models and controllers lean
+- **Naming Convention**: Name actions WITHOUT "Action" suffix - use descriptive names like `CreateOrganization`, `UpdateOffice`, `DeleteUser`
+- **Single handle() Method**: Actions MUST implement a `handle()` method (NOT `__invoke()`) that performs the business logic
+- **Create with Artisan**: Use `php artisan make:action "{Name}" --no-interaction` to create new actions
+- **Constructor Injection**: Inject dependencies via constructor using private readonly properties for services and other actions
+- **Method Parameters**: Accept Data objects and required models/context as handle() parameters
+- **Update Actions Accept Model**: Update actions MUST accept the model being updated as a parameter, not query for it inside
+- **Delete Actions Accept Model**: Delete actions MUST accept the model being deleted as a parameter, not accept ID and query
+- **Create Actions Accept Data**: Create actions accept Data object and any required context (user, parent models, etc.)
+- **Use toArray() with Optional**: Data objects automatically handle Optional fields - use `$data->toArray()` for clean updates
+- **Transactions for Complex Operations**: Wrap multi-model operations in `DB::transaction()` when needed
+- **Return Updated Models**: Return the model after updates, use `->refresh()` to get latest data
+- **No Dependencies in Simple Actions**: Some actions don't require constructor dependencies - just the handle() method
+- **Unit Test All Actions**: ALWAYS create comprehensive unit tests for Actions in `tests/Unit/Actions/`

--- a/agent-os/standards/backend/api.md
+++ b/agent-os/standards/backend/api.md
@@ -1,10 +1,12 @@
-## API endpoint standards and conventions
+## API endpoint standards
 
 - **RESTful Design**: Follow REST principles with clear resource-based URLs and appropriate HTTP methods (GET, POST, PUT, PATCH, DELETE)
-- **Consistent Naming**: Use consistent, lowercase, hyphenated or underscored naming conventions for endpoints across the API
-- **Versioning**: Implement API versioning strategy (URL path or headers) to manage breaking changes without disrupting existing clients
-- **Plural Nouns**: Use plural nouns for resource endpoints (e.g., `/users`, `/products`) for consistency
-- **Nested Resources**: Limit nesting depth to 2-3 levels maximum to keep URLs readable and maintainable
-- **Query Parameters**: Use query parameters for filtering, sorting, pagination, and search rather than creating separate endpoints
-- **HTTP Status Codes**: Return appropriate, consistent HTTP status codes that accurately reflect the response (200, 201, 400, 404, 500, etc.)
-- **Rate Limiting Headers**: Include rate limit information in response headers to help clients manage their usage
+- **Use Eloquent API Resources**: Default to using Eloquent API Resources for transforming models to JSON responses for type-safe serialization
+- **API Versioning**: Implement API versioning (URL path or headers) to manage breaking changes without disrupting existing clients
+- **Consistent Naming**: Use lowercase, hyphenated or underscored naming consistently across all API endpoints
+- **Plural Resource Names**: Use plural nouns for resource endpoints (e.g., `/users`, `/products`) for consistency
+- **Limit Nesting Depth**: Keep resource nesting to 2-3 levels maximum for readability and maintainability
+- **Query Parameters for Filtering**: Use query parameters for filtering, sorting, pagination, and search instead of separate endpoints
+- **Appropriate Status Codes**: Return correct HTTP status codes (200 OK, 201 Created, 400 Bad Request, 404 Not Found, 500 Server Error)
+- **Rate Limiting**: Include rate limit information in response headers to help clients manage usage
+- **JSON Response Format**: Maintain consistent JSON structure across all endpoints with clear error messages

--- a/agent-os/standards/backend/controllers.md
+++ b/agent-os/standards/backend/controllers.md
@@ -1,0 +1,14 @@
+## Controller standards
+
+- **Thin HTTP Adapters**: Controllers are thin adapters that validate, convert data, call actions, and return responses - NO business logic
+- **Flat Hierarchy**: Controllers live directly in `app/Http/Controllers/` - NO nested Admin/ or other subdirectories
+- **Single Action Controllers**: Use `__invoke()` for one specific action (e.g., `ActivateUserController`, `ResendInvitationController`)
+- **Multi-Action Controllers**: Use named methods for related CRUD operations (e.g., `OfficeController` with `store()`, `update()`, `destroy()`)
+- **Always Use Form Requests**: ALWAYS create dedicated Form Request classes for validation - NEVER inline validation in controllers
+- **Method-Level Injection**: Inject Actions and Queries at method level, NOT in `__construct()`
+- **Use CurrentUser Attribute**: Use `#[CurrentUser] User $user` instead of `Request::user()` for cleaner dependency injection
+- **Data Object Creation**: Create Data objects from validated data using `::from($request->validated())`
+- **Delegate to Actions**: Call Action's `handle()` method with Data objects and models - controller just orchestrates
+- **Explicit Return Types**: Always use explicit return type hints (`RedirectResponse`, `Response`, `JsonResponse`)
+- **Named Routes**: Prefer named routes with `route()` function for redirects and URL generation
+- **Flash Messages**: Use `->with('success', 'message')` for user feedback on redirects

--- a/agent-os/standards/backend/data-objects.md
+++ b/agent-os/standards/backend/data-objects.md
@@ -1,0 +1,17 @@
+## Data object standards (Spatie Laravel Data)
+
+- **DTOs Not Validation**: Data objects are DTOs for type-safe data transfer - NOT validation layers (validation belongs in Form Requests)
+- **Store in app/Data/**: All Data objects live in `app/Data/` namespace with descriptive subfolders
+- **Suffix with Data**: ALL Data objects MUST be suffixed with `Data` (e.g., `UpdateOfficeData`, `CreateUserData`, `AddressData`)
+- **Add toArray() Annotation**: ALWAYS add `@method array<string, mixed> toArray()` PHPDoc annotation to all Data objects
+- **Readonly Properties**: Use `readonly` keyword for all properties - Data objects are immutable
+- **Optional for Updates**: Use `Type|Optional` for update Data objects to support partial updates
+- **Nullable vs Optional**: `Optional` = field not provided (don't update), `null` = explicitly set to null (update to null)
+- **Required for Creates**: Use required types for create Data objects to ensure all fields provided
+- **Use SnakeCaseMapper**: Add `#[MapOutputName(SnakeCaseMapper::class)]` for internal data consistency
+- **Use CamelCaseMapper for Frontend**: Add `#[MapOutputName(CamelCaseMapper::class)]` when passing data to Inertia/React components
+- **Computed Properties**: Use `#[Computed]` attribute for derived properties - declare as properties (not methods) and initialize in constructor
+- **Create from Validated Data**: Use `DataObject::from($request->validated())` in controllers
+- **Nested Data Objects**: Use nested Data objects for related entities (e.g., Office with AddressData)
+- **No Validation Attributes**: Do NOT add validation attributes to Data objects - validation belongs in Form Requests
+- **Test Optional Handling**: ALWAYS test that Optional fields are excluded from `toArray()` output

--- a/agent-os/standards/backend/migrations.md
+++ b/agent-os/standards/backend/migrations.md
@@ -1,9 +1,13 @@
-## Database migration best practices
+## Database migration standards
 
-- **Reversible Migrations**: Always implement rollback/down methods to enable safe migration reversals
-- **Small, Focused Changes**: Keep each migration focused on a single logical change for clarity and easier troubleshooting
-- **Zero-Downtime Deployments**: Consider deployment order and backwards compatibility for high-availability systems
-- **Separate Schema and Data**: Keep schema changes separate from data migrations for better rollback safety
-- **Index Management**: Create indexes on large tables carefully, using concurrent options when available to avoid locks
-- **Naming Conventions**: Use clear, descriptive names that indicate what the migration does
-- **Version Control**: Always commit migrations to version control and never modify existing migrations after deployment
+- **Always Delete down() Method**: NEVER implement the `down()` method - this application does not roll back migrations, always remove it entirely
+- **Column Order CREATE TABLE**: ALWAYS use this exact order: `id()` first, then `timestamps()`, then all other columns
+- **No after() in ALTER TABLE**: Do NOT use `after()` method when adding columns - breaks PostgreSQL compatibility
+- **No Default Values**: Default values are business logic, NOT database constraints - implement in Model's `$attributes`, `booted()` method, or Action classes
+- **Use foreignIdFor()**: ALWAYS use `$table->foreignIdFor(Model::class)` for foreign keys instead of manual `unsignedBigInteger()`
+- **No Cascade Constraints**: NEVER add `->onDelete('cascade')` or `->onUpdate('cascade')` - handle deletions explicitly in Action classes to prevent unintended data loss
+- **Column Modification Preserves All**: When modifying a column with `->change()`, MUST include ALL previously defined attributes or they will be dropped
+- **Use migrate:fresh --seed**: Reset database with `php artisan migrate:fresh --seed` instead of rolling back migrations
+- **Small Focused Changes**: Keep each migration focused on a single logical change for clarity and easier troubleshooting
+- **Descriptive Names**: Use clear, descriptive migration names that indicate what the migration does
+- **Version Control**: Always commit migrations to version control and never modify existing deployed migrations

--- a/agent-os/standards/backend/models.md
+++ b/agent-os/standards/backend/models.md
@@ -1,10 +1,13 @@
-## Database model best practices
+## Eloquent model standards
 
-- **Clear Naming**: Use singular names for models and plural for tables following your framework's conventions
-- **Timestamps**: Include created and updated timestamps on all tables for auditing and debugging
-- **Data Integrity**: Use database constraints (NOT NULL, UNIQUE, foreign keys) to enforce data rules at the database level
-- **Appropriate Data Types**: Choose data types that match the data's purpose and size requirements
-- **Indexes on Foreign Keys**: Index foreign key columns and other frequently queried fields for performance
-- **Validation at Multiple Layers**: Implement validation at both model and database levels for defense in depth
-- **Relationship Clarity**: Define relationships clearly with appropriate cascade behaviors and naming conventions
-- **Avoid Over-Normalization**: Balance normalization with practical query performance needs
+- **Type Hints Required**: Add PHPDoc `@property` and `@property-read` annotations for all database fields, casts, and relationships
+- **Relationship Return Types**: Always add PHPDoc return type hints with PHPStan generics (e.g., `@return BelongsTo<Organization, $this>`)
+- **Casts Method**: Use public `casts()` method (not `$casts` property) for Laravel 11+ with explicit type casting for id, foreign keys, enums, and timestamps
+- **Readonly Relationships**: Use `@property-read` for ALL relationships since relationships are always read-only
+- **Lean Models**: Keep models minimal - only relationships, simple accessors/mutators, casts, and simple boolean helpers (e.g., `isAdmin()`)
+- **No Business Logic**: Do NOT add update/create methods to models - all business logic belongs in Action classes
+- **Factory Type Hints**: Use `@use HasFactory<ModelFactory>` annotation for factory support
+- **Final Classes**: Declare models as final to prevent inheritance and ensure immutability
+- **Strict Types**: Always use `declare(strict_types=1);` at the top of model files
+- **Clear Naming**: Use singular names for models and plural for table names
+- **Model Structure Order**: PHPDoc block → class declaration → traits → relationship methods → casts() method → other methods

--- a/agent-os/standards/backend/queries.md
+++ b/agent-os/standards/backend/queries.md
@@ -1,9 +1,13 @@
-## Database query best practices
+## Query class standards
 
-- **Prevent SQL Injection**: Always use parameterized queries or ORM methods; never interpolate user input into SQL strings
-- **Avoid N+1 Queries**: Use eager loading or joins to fetch related data in a single query instead of multiple queries
-- **Select Only Needed Data**: Request only the columns you need rather than using SELECT * for better performance
-- **Index Strategic Columns**: Index columns used in WHERE, JOIN, and ORDER BY clauses for query optimization
-- **Use Transactions for Related Changes**: Wrap related database operations in transactions to maintain data consistency
-- **Set Query Timeouts**: Implement timeouts to prevent runaway queries from impacting system performance
-- **Cache Expensive Queries**: Cache results of complex or frequently-run queries when appropriate
+- **Query Builder Pattern**: Create Query classes in `app/Queries/` that provide reusable query builders for complex database reads
+- **Required builder() Method**: ALL Query classes MUST implement a `builder()` method that returns an Eloquent or Query Builder instance
+- **Naming Convention**: Use singular model name + "Query" suffix (e.g., `CountryQuery`, `UserQuery`, not `GetUsersQuery`)
+- **Return Type Hints**: Always use generic type hints for builder() method: `@return Builder<Model>`
+- **Method Injection**: Inject Query classes at the method level in controllers, NOT in `__construct()`
+- **Read Operations Only**: Queries handle SELECT operations - write operations (INSERT, UPDATE, DELETE) belong in Actions
+- **No Business Logic**: Queries should not contain business logic, data transformation, or validation
+- **Chainable Methods**: Return builder instances to allow method chaining in controllers
+- **Always Use Model::query()**: NEVER use `Model::all()`, `Model::find()`, or `Model::where()` directly - always start with `Model::query()`
+- **Prevent N+1 Queries**: Use eager loading to prevent N+1 query problems
+- **Avoid DB Facade**: Prefer `Model::query()` over `DB::` facade to leverage Laravel's ORM capabilities

--- a/agent-os/standards/frontend/accessibility.md
+++ b/agent-os/standards/frontend/accessibility.md
@@ -1,10 +1,13 @@
-## UI accessibility best practices
+## Accessibility standards
 
-- **Semantic HTML**: Use appropriate HTML elements (nav, main, button, etc.) that convey meaning to assistive technologies
-- **Keyboard Navigation**: Ensure all interactive elements are accessible via keyboard with visible focus indicators
-- **Color Contrast**: Maintain sufficient contrast ratios (4.5:1 for normal text) and don't rely solely on color to convey information
+- **shadcn/ui Built-in Accessibility**: shadcn/ui components have built-in accessibility - use them for consistent a11y
+- **Semantic HTML**: Use appropriate HTML elements (nav, main, button, article) that convey meaning to assistive technologies
+- **Keyboard Navigation**: Ensure all interactive elements accessible via keyboard with visible focus indicators
+- **Color Contrast**: Maintain sufficient contrast ratios (4.5:1 for normal text) - test with both light and dark modes
 - **Alternative Text**: Provide descriptive alt text for images and meaningful labels for all form inputs
-- **Screen Reader Testing**: Test and verify that all views are accessible on screen reading devices.
-- **ARIA When Needed**: Use ARIA attributes to enhance complex components when semantic HTML isn't sufficient
-- **Logical Heading Structure**: Use heading levels (h1-h6) in proper order to create a clear document outline
-- **Focus Management**: Manage focus appropriately in dynamic content, modals, and single-page applications
+- **Form Labels**: Use shadcn/ui Label component properly associated with Input components via htmlFor
+- **Screen Reader Testing**: Test views with screen reading devices to ensure proper experience
+- **ARIA When Needed**: Use ARIA attributes to enhance complex components when semantic HTML insufficient
+- **Logical Heading Structure**: Use heading levels (h1-h6) in proper order to create clear document outline
+- **Focus Management**: Manage focus in modals (Dialog/Sheet components), dynamic content, and page transitions
+- **Dark Mode Support**: If pages support dark mode, ensure accessibility maintained in both themes

--- a/agent-os/standards/frontend/components.md
+++ b/agent-os/standards/frontend/components.md
@@ -1,11 +1,15 @@
-## UI component best practices
+## React component standards
 
-- **Single Responsibility**: Each component should have one clear purpose and do it well
-- **Reusability**: Design components to be reused across different contexts with configurable props
-- **Composability**: Build complex UIs by combining smaller, simpler components rather than monolithic structures
-- **Clear Interface**: Define explicit, well-documented props with sensible defaults for ease of use
-- **Encapsulation**: Keep internal implementation details private and expose only necessary APIs
-- **Consistent Naming**: Use clear, descriptive names that indicate the component's purpose and follow team conventions
-- **State Management**: Keep state as local as possible; lift it up only when needed by multiple components
-- **Minimal Props**: Keep the number of props manageable; if a component needs many props, consider composition or splitting it
-- **Documentation**: Document component usage, props, and provide examples for easier adoption by team members
+- **Functional Components Only**: Use functional components with hooks - NO class components
+- **TypeScript Interfaces**: Define props interface for every component with proper typing
+- **Check Existing Components**: ALWAYS check `resources/js/components/ui/` for shadcn/ui components before creating new ones
+- **Reuse shadcn/ui**: Use existing shadcn/ui components (Button, Card, Input, Select, Dialog, Sheet, etc.) for consistency
+- **File Naming**: Use lowercase with hyphens (e.g., `user-profile.tsx`, not `UserProfile.tsx`)
+- **Export Default for Pages**: Page components use `export default`, reusable components can use named exports
+- **Component Organization**: UI primitives in `ui/`, reusable components in `components/`, layouts in `layouts/`, pages in `pages/`
+- **Flat Page Structure**: Pages live in `resources/js/pages/` with lowercase folders - NO deep nesting like `Admin/Users/Index.tsx`
+- **Import from @/components/ui/**: Use path alias when importing shadcn/ui components
+- **Single Responsibility**: Each component should have one clear, focused purpose
+- **Props Interface**: Use `interface` over `type` for component props definitions
+- **No any Type**: Avoid using `any` - use proper TypeScript types
+- **Import Types**: Use `import type` for type-only imports to optimize bundle size

--- a/agent-os/standards/frontend/css.md
+++ b/agent-os/standards/frontend/css.md
@@ -1,7 +1,12 @@
-## CSS best practices
+## Tailwind CSS standards
 
-- **Consistent Methodology**: Apply and stick to the project's consistent CSS methodology (Tailwind, BEM, utility classes, CSS modules, etc.) across the entire project
-- **Avoid Overriding Framework Styles**: Work with your framework's patterns rather than fighting against them with excessive overrides
-- **Maintain Design System**: Establish and document design tokens (colors, spacing, typography) for consistency
-- **Minimize Custom CSS**: Leverage framework utilities and components to reduce custom CSS maintenance burden
-- **Performance Considerations**: Optimize for production with CSS purging/tree-shaking to remove unused styles
+- **Use Tailwind v4**: Always use Tailwind CSS v4 - do not use deprecated utilities from v3
+- **Import Statement**: Use `@import "tailwindcss";` in CSS files, NOT the old `@tailwind` directives
+- **Replaced Utilities**: Use new utilities: `bg-black/*` not `bg-opacity-*`, `shrink-*` not `flex-shrink-*`, `text-ellipsis` not `overflow-ellipsis`
+- **Check Existing Conventions**: Review and use existing Tailwind conventions within the project before writing your own
+- **Gap for Spacing**: Use gap utilities for spacing in flex/grid layouts instead of margins
+- **Dark Mode Support**: If existing pages support dark mode with `dark:` prefix, new pages must also support it consistently
+- **Minimize Custom CSS**: Leverage Tailwind utilities to reduce custom CSS maintenance
+- **Class Organization**: Think through class placement, order, and priority - remove redundant classes, group elements logically
+- **Component Extraction**: Extract repeated Tailwind patterns into reusable React components
+- **No corePlugins**: `corePlugins` configuration is not supported in Tailwind v4

--- a/agent-os/standards/frontend/inertia.md
+++ b/agent-os/standards/frontend/inertia.md
@@ -1,0 +1,17 @@
+## Inertia.js standards (React)
+
+- **React with Inertia**: This application uses React with Inertia.js v2 - NOT Vue.js
+- **Page Components**: Inertia pages are React components in `resources/js/pages/` directory with lowercase folder names
+- **TSX Extension**: Page components use `.tsx` extension for TypeScript + JSX
+- **Server-Side Routing**: Use `Inertia::render()` in controllers for server-side routing instead of traditional Blade views
+- **Props Interface**: Define TypeScript interface for page component props
+- **Head Component**: Use `<Head>` from `@inertiajs/react` for page titles and meta tags
+- **useForm Hook**: ALWAYS use Inertia's `useForm` hook for form handling - provides processing state and errors
+- **Type-Safe Forms**: Define form data interface and use with `useForm<FormData>()`
+- **Error Display**: Use `form.errors` for displaying validation errors from Laravel
+- **Loading States**: Use `form.processing` for submit button disabled state and loading indicators
+- **Polling**: Use Inertia v2 polling feature for real-time data updates
+- **Prefetching**: Use prefetching to preload data for faster page transitions
+- **Deferred Props**: Use deferred props for lazy-loading data with loading skeletons
+- **Infinite Scrolling**: Use merging props and `WhenVisible` for infinite scroll implementations
+- **Backend Validation**: Validation happens in Laravel Form Requests - frontend displays errors from backend

--- a/agent-os/standards/frontend/responsive.md
+++ b/agent-os/standards/frontend/responsive.md
@@ -1,11 +1,13 @@
-## Responsive design best practices
+## Responsive design standards
 
-- **Mobile-First Development**: Start with mobile layout and progressively enhance for larger screens
-- **Standard Breakpoints**: Consistently use standard breakpoints across the application (e.g., mobile, tablet, desktop)
-- **Fluid Layouts**: Use percentage-based widths and flexible containers that adapt to screen size
-- **Relative Units**: Prefer rem/em units over fixed pixels for better scalability and accessibility
-- **Test Across Devices**: Test and verify UI changes across multiple screen sizes from mobile to tablet to desktop screen sizes and ensure a balanced, user-friendly viewing and reading experience on all
-- **Touch-Friendly Design**: Ensure tap targets are appropriately sized (minimum 44x44px) for mobile users
-- **Performance on Mobile**: Optimize images and assets for mobile network conditions and smaller screens
+- **Tailwind Breakpoints**: Use Tailwind's responsive prefixes (sm:, md:, lg:, xl:, 2xl:) consistently across application
+- **Mobile-First Development**: Start with mobile layout and progressively enhance with breakpoint prefixes
+- **Test Across Devices**: Test UI changes across multiple screen sizes (mobile, tablet, desktop) for balanced experience
+- **Fluid Layouts**: Use Tailwind's responsive width utilities and flexible containers that adapt to screen size
+- **Relative Units**: Tailwind uses rem units by default - avoid fixed pixel values when possible
+- **Touch-Friendly Design**: Ensure tap targets appropriately sized (minimum 44x44px) for mobile users
+- **Pest Browser Testing**: Use Pest v4 browser testing with different viewports to test responsive behavior
+- **Performance on Mobile**: Optimize images with proper sizing and lazy loading for mobile networks
 - **Readable Typography**: Maintain readable font sizes across all breakpoints without requiring zoom
-- **Content Priority**: Show the most important content first on smaller screens through thoughtful layout decisions
+- **Content Priority**: Show most important content first on smaller screens through thoughtful layout
+- **Dark Mode Responsive**: Ensure dark mode works across all breakpoints if implemented

--- a/agent-os/standards/frontend/typescript.md
+++ b/agent-os/standards/frontend/typescript.md
@@ -1,0 +1,14 @@
+## TypeScript standards
+
+- **Proper Typing**: Type all props, state, and function parameters explicitly
+- **Interface Over Type**: Prefer `interface` for component props and object shapes
+- **No any Type**: Avoid using `any` type - use proper types or `unknown` when type is truly unknown
+- **Import Types**: Use `import type` for type-only imports to optimize bundle size
+- **Type-Safe Forms**: Define form data interfaces for useForm hook usage
+- **Explicit Return Types**: Add return type annotations to functions for clarity
+- **Generic Types**: Use generic types for reusable components and utilities
+- **Null Safety**: Handle nullable types explicitly with optional chaining and nullish coalescing
+- **Enum Usage**: Use TypeScript enums or const objects for sets of related constants
+- **Strict Mode**: Ensure TypeScript strict mode is enabled in tsconfig.json
+- **Type Guards**: Use type guards for runtime type checking when needed
+- **Utility Types**: Leverage TypeScript utility types (Partial, Pick, Omit, etc.) for type transformations

--- a/agent-os/standards/global/coding-style.md
+++ b/agent-os/standards/global/coding-style.md
@@ -1,10 +1,15 @@
-## Coding style best practices
+## Coding style standards
 
-- **Consistent Naming Conventions**: Establish and follow naming conventions for variables, functions, classes, and files across the codebase
-- **Automated Formatting**: Maintain consistent code style (indenting, line breaks, etc.)
-- **Meaningful Names**: Choose descriptive names that reveal intent; avoid abbreviations and single-letter variables except in narrow contexts
-- **Small, Focused Functions**: Keep functions small and focused on a single task for better readability and testability
-- **Consistent Indentation**: Use consistent indentation (spaces or tabs) and configure your editor/linter to enforce it
-- **Remove Dead Code**: Delete unused code, commented-out blocks, and imports rather than leaving them as clutter
-- **Backward compatibility only when required:** Unless specifically instructed otherwise, assume you do not need to write additional code logic to handle backward compatibility.
-- **DRY Principle**: Avoid duplication by extracting common logic into reusable functions or modules
+- **Strict Types in PHP**: Always use `declare(strict_types=1);` at the top of all PHP files
+- **Explicit Return Types**: Always use explicit return type declarations for methods and functions in PHP
+- **Type Hints for Parameters**: Use appropriate type hints for all method and function parameters
+- **Curly Braces Required**: Always use curly braces for control structures, even single-line blocks
+- **Method Chaining on New Lines**: Chain methods on new lines for better readability
+- **PHP 8 Constructor Promotion**: Use PHP 8 constructor property promotion in `__construct()`
+- **No Empty Constructors**: Do not allow empty `__construct()` methods with zero parameters
+- **Run Laravel Pint**: ALWAYS run `vendor/bin/pint --dirty` before committing to format code
+- **Descriptive Names**: Use descriptive names for variables and methods (e.g., `isRegisteredForDiscounts`, not `discount()`)
+- **Check Existing Conventions**: When creating or editing files, check sibling files for correct structure, approach, and naming
+- **Small Focused Functions**: Keep functions small and focused on a single task
+- **Remove Dead Code**: Delete unused code, commented-out blocks, and imports
+- **DRY Principle**: Avoid duplication by extracting common logic into reusable classes or methods

--- a/agent-os/standards/global/commenting.md
+++ b/agent-os/standards/global/commenting.md
@@ -1,5 +1,10 @@
-## Code commenting best practices
+## Code commenting standards
 
-- **Self-Documenting Code**: Write code that explains itself through clear structure and naming
-- **Minimal, helpful comments**: Add concise, minimal comments to explain large sections of code logic.
-- **Don't comment changes or fixes**: Do not leave code comments that speak to recent or temporary changes or fixes. Comments should be evergreen informational texts that are relevant far into the future.
+- **Prefer PHPDoc Over Comments**: Use PHPDoc blocks over inline comments - never use comments within code unless very complex
+- **PHPDoc for Type Hints**: Add PHPDoc annotations for properties, relationships, array shapes, and return types
+- **Self-Documenting Code**: Write clear, descriptive code through structure and naming
+- **Minimal Comments**: Add concise comments only to explain complex logic or "why" decisions
+- **No Superfluous Annotations**: Don't include superfluous PHP annotations except ones starting with `@` for typing
+- **Array Shape Documentation**: Add useful array shape type definitions for arrays in PHPDoc when appropriate
+- **No Temporal Comments**: Do NOT leave comments about recent changes or temporary fixes - comments should be evergreen
+- **Enum Keys TitleCase**: Enum keys should be TitleCase (e.g., `FavoritePerson`, `BestLake`, `Monthly`)

--- a/agent-os/standards/global/conventions.md
+++ b/agent-os/standards/global/conventions.md
@@ -1,11 +1,15 @@
 ## General development conventions
 
-- **Consistent Project Structure**: Organize files and directories in a predictable, logical structure that team members can navigate easily
-- **Clear Documentation**: Maintain up-to-date README files with setup instructions, architecture overview, and contribution guidelines
-- **Version Control Best Practices**: Use clear commit messages, feature branches, and meaningful pull/merge requests with descriptions
-- **Environment Configuration**: Use environment variables for configuration; never commit secrets or API keys to version control
-- **Dependency Management**: Keep dependencies up-to-date and minimal; document why major dependencies are used
-- **Code Review Process**: Establish a consistent code review process with clear expectations for reviewers and authors
-- **Testing Requirements**: Define what level of testing is required before merging (unit tests, integration tests, etc.)
-- **Feature Flags**: Use feature flags for incomplete features rather than long-lived feature branches
-- **Changelog Maintenance**: Keep a changelog or release notes to track significant changes and improvements
+- **Follow Existing Conventions**: MUST follow all existing code conventions - check sibling files for structure, approach, naming
+- **Stick to Directory Structure**: Do not create new base folders without approval - stick to existing structure
+- **No Dependency Changes**: Do not change application dependencies without approval
+- **Use Artisan Commands**: Use `php artisan make:` commands to create new files (migrations, controllers, models, etc.)
+- **Pass --no-interaction**: Always pass `--no-interaction` to Artisan commands to ensure they work without user input
+- **Environment Variables in Config**: Use environment variables ONLY in config files - never use `env()` outside of config/ directory
+- **Named Routes**: Prefer named routes and `route()` function when generating links
+- **SessionKey Enum**: ALWAYS use `SessionKey` enum for session key management instead of magic strings
+- **Version Control Best Practices**: Use clear commit messages, feature branches, and meaningful pull/merge requests
+- **Never Commit Secrets**: Never commit secrets, API keys, or .env files to version control
+- **Testing Before Commits**: ALWAYS run `php artisan test` and `vendor/bin/pint --dirty` before every commit
+- **Feature Branches**: Always create new feature branch when starting new task - fetch and pull latest from main first
+- **Branch Naming**: Use descriptive branch names like `feature/descriptive-name`

--- a/agent-os/standards/global/error-handling.md
+++ b/agent-os/standards/global/error-handling.md
@@ -1,9 +1,12 @@
-## Error handling best practices
+## Error handling standards
 
-- **User-Friendly Messages**: Provide clear, actionable error messages to users without exposing technical details or security information
-- **Fail Fast and Explicitly**: Validate input and check preconditions early; fail with clear error messages rather than allowing invalid state
-- **Specific Exception Types**: Use specific exception/error types rather than generic ones to enable targeted handling
-- **Centralized Error Handling**: Handle errors at appropriate boundaries (controllers, API layers) rather than scattering try-catch blocks everywhere
-- **Graceful Degradation**: Design systems to degrade gracefully when non-critical services fail rather than breaking entirely
-- **Retry Strategies**: Implement exponential backoff for transient failures in external service calls
-- **Clean Up Resources**: Always clean up resources (file handles, connections) in finally blocks or equivalent mechanisms
+- **Laravel Exception Handling**: Use Laravel's built-in exception handling in `bootstrap/app.php` for centralized error management
+- **Form Request Validation Errors**: Validation errors automatically returned by Form Requests - frontend displays using `form.errors`
+- **Action Layer Exceptions**: Throw specific exceptions from Action classes for business logic errors
+- **User-Friendly Messages**: Provide clear, actionable error messages without exposing technical details or security information
+- **Fail Fast**: Validate input and check preconditions early in Actions - fail with clear exceptions before processing
+- **Specific Exception Types**: Use specific exception types (ValidationException, AuthorizationException, etc.) for targeted handling
+- **No try-catch Everywhere**: Handle errors at appropriate boundaries (controllers, Actions) not scattered try-catch blocks
+- **Transactions for Safety**: Use `DB::transaction()` in Actions for multi-model operations to ensure atomicity
+- **Clean Up Resources**: Always clean up resources (file handles, connections) in finally blocks
+- **Log Errors**: Use Laravel's logging for errors - check with `last-error` MCP tool or `read-log-entries`

--- a/agent-os/standards/global/tech-stack.md
+++ b/agent-os/standards/global/tech-stack.md
@@ -1,31 +1,45 @@
 ## Tech stack
 
-Define your technical stack below. This serves as a reference for all team members and helps maintain consistency across the project.
+This application's technical stack with specific versions for consistency across development.
 
-### Framework & Runtime
-- **Application Framework:** [e.g., Rails, Django, Next.js, Express]
-- **Language/Runtime:** [e.g., Ruby, Python, Node.js, Java]
-- **Package Manager:** [e.g., bundler, pip, npm, yarn]
+### Backend Framework & Runtime
+- **Framework:** Laravel 12
+- **Language:** PHP 8.4.13
+- **Authentication:** Laravel Fortify v1
+- **Permissions:** Spatie Laravel Permission v6
+- **Settings:** Spatie Laravel Settings v3
+- **Data Objects:** Spatie Laravel Data v4
+- **Package Manager:** Composer
 
 ### Frontend
-- **JavaScript Framework:** [e.g., React, Vue, Svelte, Alpine, vanilla JS]
-- **CSS Framework:** [e.g., Tailwind CSS, Bootstrap, custom]
-- **UI Components:** [e.g., shadcn/ui, Material UI, custom library]
+- **JavaScript Framework:** React 18
+- **Language:** TypeScript 5
+- **CSS Framework:** Tailwind CSS v4
+- **UI Components:** shadcn/ui
+- **SPA Framework:** Inertia.js v2 (@inertiajs/react)
+- **Build Tool:** Vite 6
+- **Code Formatter:** Prettier 3
 
-### Database & Storage
-- **Database:** [e.g., PostgreSQL, MySQL, MongoDB]
-- **ORM/Query Builder:** [e.g., ActiveRecord, Prisma, Sequelize]
-- **Caching:** [e.g., Redis, Memcached]
+### Database & ORM
+- **ORM:** Laravel Eloquent
+- **Query Builder:** Laravel Query Builder
+- **Migrations:** Laravel Migrations
 
 ### Testing & Quality
-- **Test Framework:** [e.g., Jest, RSpec, pytest]
-- **Linting/Formatting:** [e.g., ESLint, Prettier, RuboCop]
+- **Test Framework:** Pest v4 (PHPUnit v12)
+- **PHP Linter:** Laravel Pint v1
+- **Static Analysis:** Larastan v3 (PHPStan)
+- **Refactoring:** Rector v2
+- **Frontend Testing:** Pest v4 Browser Testing
 
-### Deployment & Infrastructure
-- **Hosting:** [e.g., Heroku, AWS, Vercel, Railway]
-- **CI/CD:** [e.g., GitHub Actions, CircleCI]
+### Development Tools
+- **MCP Server:** Laravel MCP v0
+- **Prompts:** Laravel Prompts v0
+- **Wayfinder:** Laravel Wayfinder v0
 
-### Third-Party Services
-- **Authentication:** [e.g., Auth0, Devise, NextAuth]
-- **Email:** [e.g., SendGrid, Postmark]
-- **Monitoring:** [e.g., Sentry, Datadog]
+### Architecture Patterns
+- **Action Pattern:** Business logic in Action classes
+- **Query Pattern:** Data access in Query classes
+- **Data Transfer:** Spatie Laravel Data for DTOs
+- **Form Validation:** Laravel Form Requests
+- **Lean Models:** Models contain only relationships, casts, and simple helpers

--- a/agent-os/standards/global/validation.md
+++ b/agent-os/standards/global/validation.md
@@ -1,11 +1,14 @@
-## Validation best practices
+## Validation standards
 
-- **Validate on Server Side**: Always validate on the server; never trust client-side validation alone for security or data integrity
-- **Client-Side for UX**: Use client-side validation to provide immediate user feedback, but duplicate checks server-side
+- **Form Requests for HTTP Validation**: ALWAYS create Form Request classes for validation - NEVER inline validation in controllers
+- **Data Objects Are NOT Validators**: Data objects are DTOs for type-safe transfer - validation belongs in Form Requests
+- **Separation of Concerns**: Form Requests validate, Data objects transfer, Actions contain business logic
+- **Server-Side Validation**: Always validate on server; never trust client-side validation alone for security
+- **Client-Side for UX**: Frontend displays validation errors from backend - use `form.errors` in Inertia
+- **Specific Error Messages**: Provide clear, field-specific error messages in Form Request's `messages()` method
+- **Array or String Rules**: Check sibling Form Requests to see if application uses array or string-based validation rules
+- **Authorization in Form Requests**: Use Form Request's `authorize()` method for permission checks
 - **Fail Early**: Validate input as early as possible and reject invalid data before processing
-- **Specific Error Messages**: Provide clear, field-specific error messages that help users correct their input
-- **Allowlists Over Blocklists**: When possible, define what is allowed rather than trying to block everything that's not
 - **Type and Format Validation**: Check data types, formats, ranges, and required fields systematically
-- **Sanitize Input**: Sanitize user input to prevent injection attacks (SQL, XSS, command injection)
-- **Business Rule Validation**: Validate business rules (e.g., sufficient balance, valid dates) at the appropriate application layer
-- **Consistent Validation**: Apply validation consistently across all entry points (web forms, API endpoints, background jobs)
+- **Sanitize Input**: Laravel automatically sanitizes to prevent injection attacks when using parameterized queries/ORM
+- **Business Rule Validation**: Complex business rules belong in Action classes, not Form Requests

--- a/agent-os/standards/testing/test-writing.md
+++ b/agent-os/standards/testing/test-writing.md
@@ -1,9 +1,22 @@
-## Test coverage best practices
+## Test writing standards (Pest v4)
 
-- **Write Minimal Tests During Development**: Do NOT write tests for every change or intermediate step. Focus on completing the feature implementation first, then add strategic tests only at logical completion points
-- **Test Only Core User Flows**: Write tests exclusively for critical paths and primary user workflows. Skip writing tests for non-critical utilities and secondary workflows until if/when you're instructed to do so.
-- **Defer Edge Case Testing**: Do NOT test edge cases, error states, or validation logic unless they are business-critical. These can be addressed in dedicated testing phases, not during feature development.
-- **Test Behavior, Not Implementation**: Focus tests on what the code does, not how it does it, to reduce brittleness
-- **Clear Test Names**: Use descriptive names that explain what's being tested and the expected outcome
-- **Mock External Dependencies**: Isolate units by mocking databases, APIs, file systems, and other external services
-- **Fast Execution**: Keep unit tests fast (milliseconds) so developers run them frequently during development
+- **Full Test Coverage Required**: Write comprehensive tests for ALL features covering happy paths, failure paths, edge cases, and error conditions
+- **All Tests Must Pass Before Commits**: ALWAYS run `php artisan test` before every commit - all tests must pass
+- **Use Pest Framework**: All tests written using Pest v4 - use `php artisan make:test --pest <name>` for feature tests, add `--unit` for unit tests
+- **Flat Test Structure**: NO nested subdirectories in test folders - `tests/Unit/Actions/CreateOfficeTest.php` NOT `tests/Unit/Actions/Office/CreateOfficeTest.php`
+- **Imperative Test Names**: Use imperative mood (e.g., `test('creates user with valid data')`) NOT "it" statements (NOT `test('it creates user')`)
+- **New Tests First**: Place newly written tests at the TOP of the file before existing tests
+- **Always Import Classes**: ALWAYS import all classes used - never use fully qualified class names inline
+- **Chain expect() Methods**: Chain multiple assertions on same expect() call for cleaner tests
+- **Type Hint All Variables**: Add PHPDoc type hints for all variables and explicit return types for test functions (`: void`)
+- **Use createQuietly()**: ALWAYS use `createQuietly()` instead of `create()` to prevent model events from firing
+- **Use fresh() for Seeded Data**: For records from migrations/seeders use `->first()?->fresh()` to get latest data
+- **Container Resolution for Actions**: Use `app(ActionClass::class)` in `beforeEach()` hook, NEVER `new ActionClass()`
+- **Reusable Data in beforeEach**: Define reusable models and actions in `beforeEach()` hook when used across multiple tests
+- **throws() for Exceptions**: Use Pest's `->throws()` method for exception testing, NOT `expect()->toThrow()`
+- **Authentication with $this->actingAs()**: Use `$this->actingAs($user)` for authentication, NOT `actingAs()` or `Auth::login()`
+- **Browser Tests Use visit()**: Use `visit()` function (no `$this->`) for Pest v4 browser tests
+- **Global RefreshDatabase**: `RefreshDatabase` applied globally in `tests/Pest.php` - do NOT add in individual test files
+- **@throws Annotation Before Closure**: Add `@throws Throwable` annotation BEFORE the function closure for all tests and beforeEach hooks
+- **Test Behavior Not Implementation**: Focus on what code does, not how it does it
+- **Never Remove Tests**: Do NOT remove tests or test files without approval - they are core to the application

--- a/app/Actions/CountrySubdivision/CreateRootCountrySubdivision.php
+++ b/app/Actions/CountrySubdivision/CreateRootCountrySubdivision.php
@@ -6,7 +6,9 @@ namespace App\Actions\CountrySubdivision;
 
 use App\Data\PeopleDear\CountrySubdivision\CreateCountrySubdivisionData;
 use App\Models\CountrySubdivision;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 final readonly class CreateRootCountrySubdivision
 {
@@ -14,6 +16,9 @@ final readonly class CreateRootCountrySubdivision
         private CreateCountrySubdivision $createCountrySubdivision
     ) {}
 
+    /**
+     * @throws Throwable
+     */
     public function handle(CreateCountrySubdivisionData $data): CountrySubdivision
     {
         return DB::transaction(function () use ($data): CountrySubdivision {
@@ -33,7 +38,7 @@ final readonly class CreateRootCountrySubdivision
 
             $root = $this->createCountrySubdivision->handle($dataWithoutChildren);
 
-            if ($children instanceof \Illuminate\Support\Collection && $children->isNotEmpty()) {
+            if ($children instanceof Collection && $children->isNotEmpty()) {
                 $this->createChildren($children, $root->id, $data->countryId);
             }
 
@@ -42,9 +47,9 @@ final readonly class CreateRootCountrySubdivision
     }
 
     /**
-     * @param  \Illuminate\Support\Collection<int, CreateCountrySubdivisionData>  $children
+     * @param  Collection<int, CreateCountrySubdivisionData>  $children
      */
-    private function createChildren(\Illuminate\Support\Collection $children, int $parentId, int $countryId): void
+    private function createChildren(Collection $children, int $parentId, int $countryId): void
     {
         foreach ($children as $childData) {
             $grandchildren = $childData->children;


### PR DESCRIPTION
This pull request introduces initial planning and specification documents for the new feature to fetch country subdivisions from the OpenHolidays API during the installation process. The documentation outlines both the raw idea and detailed requirements, including integration points, data mapping strategies, error handling, and technical considerations. The specification provides a comprehensive blueprint for implementing subdivision fetching for Portugal and Spain, ensuring support for nested hierarchies, type mapping, upsert logic, and robust error handling.

Requirements and Planning Documentation:

* Added `raw-idea.md` describing the motivation and high-level approach for fetching country subdivisions after country creation in the `InstallCommand`.
* Added `requirements.md` detailing functional requirements, integration points, error handling, mapping strategies, technical considerations, and scope boundaries for the subdivision fetching feature.

Feature Specification:

* Added `spec.md` with a full specification for fetching country subdivisions, including user stories, API integration details, adapter and mapping patterns, error handling, rate limiting, and testing strategy.